### PR TITLE
lesson2: 画像をリサイズして表示（clip）

### DIFF
--- a/SwiftUI100knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100knocks.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		914F2F1F29D8719A00045440 /* SwiftUI100knocksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914F2F1E29D8719A00045440 /* SwiftUI100knocksTests.swift */; };
 		914F2F2929D8719A00045440 /* SwiftUI100knocksUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914F2F2829D8719A00045440 /* SwiftUI100knocksUITests.swift */; };
 		914F2F2B29D8719A00045440 /* SwiftUI100knocksUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914F2F2A29D8719A00045440 /* SwiftUI100knocksUITestsLaunchTests.swift */; };
+		916BF27629D8913D00987A60 /* Lesson2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF27529D8913D00987A60 /* Lesson2View.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +45,7 @@
 		914F2F2429D8719A00045440 /* SwiftUI100knocksUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftUI100knocksUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		914F2F2829D8719A00045440 /* SwiftUI100knocksUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI100knocksUITests.swift; sourceTree = "<group>"; };
 		914F2F2A29D8719A00045440 /* SwiftUI100knocksUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI100knocksUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		916BF27529D8913D00987A60 /* Lesson2View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson2View.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				914F2F0F29D8719900045440 /* Lesson1View.swift */,
+				916BF27529D8913D00987A60 /* Lesson2View.swift */,
 			);
 			path = Lessons;
 			sourceTree = "<group>";
@@ -266,6 +269,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				914F2F1029D8719900045440 /* Lesson1View.swift in Sources */,
+				916BF27629D8913D00987A60 /* Lesson2View.swift in Sources */,
 				914F2F0E29D8719900045440 /* SwiftUI100knocksApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftUI100knocks/Lessons/Lesson2View.swift
+++ b/SwiftUI100knocks/Lessons/Lesson2View.swift
@@ -1,0 +1,29 @@
+//
+//  Lesson2View.swift
+//  SwiftUI100knocks
+//
+//  Created by Juri Ohto on 2023/04/02.
+//
+
+/*
+ 150✖︎200サイズに画像をリサイズして表示させてください。
+ アスペクト比が異なる場合ははみ出た箇所を切り取って表示してください。
+ */
+
+import SwiftUI
+
+struct Lesson2View: View {
+    var body: some View {
+        Image("pyramid")
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(width: 150, height: 200, alignment: .center)
+            .clipped()
+    }
+}
+
+struct Lesson2View_Previews: PreviewProvider {
+    static var previews: some View {
+        Lesson2View()
+    }
+}


### PR DESCRIPTION
## 課題
150✖︎200サイズに画像をリサイズして表示させてください。
アスペクト比が異なる場合ははみ出た箇所を切り取って表示してください。

## スクリーンショット
| お手本 | 自分の作品 |
| :----: | :----: |
| <img src="https://camo.qiitausercontent.com/10fe6e360965e273f14555df1038e973a9748ebd/68747470733a2f2f71696974612d696d6167652d73746f72652e73332e61702d6e6f727468656173742d312e616d617a6f6e6177732e636f6d2f302f36333835352f38363366373035332d323732332d663966372d666333352d6235653531636139393235362e706e67" width="300" /> |  <img src="https://user-images.githubusercontent.com/76898162/229303125-0d9d90a7-5802-46e1-9a44-6656f8364212.png" width="300" /> |