### PR TITLE
Lesson3: 画像を丸く切り取る

### DIFF
--- a/SwiftUI100knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100knocks.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		914F2F2929D8719A00045440 /* SwiftUI100knocksUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914F2F2829D8719A00045440 /* SwiftUI100knocksUITests.swift */; };
 		914F2F2B29D8719A00045440 /* SwiftUI100knocksUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914F2F2A29D8719A00045440 /* SwiftUI100knocksUITestsLaunchTests.swift */; };
 		916BF27629D8913D00987A60 /* Lesson2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF27529D8913D00987A60 /* Lesson2View.swift */; };
+		916BF27829D897E500987A60 /* Lesson3View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF27729D897E500987A60 /* Lesson3View.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,7 @@
 		914F2F2829D8719A00045440 /* SwiftUI100knocksUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI100knocksUITests.swift; sourceTree = "<group>"; };
 		914F2F2A29D8719A00045440 /* SwiftUI100knocksUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI100knocksUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		916BF27529D8913D00987A60 /* Lesson2View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson2View.swift; sourceTree = "<group>"; };
+		916BF27729D897E500987A60 /* Lesson3View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson3View.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -134,6 +136,7 @@
 			children = (
 				914F2F0F29D8719900045440 /* Lesson1View.swift */,
 				916BF27529D8913D00987A60 /* Lesson2View.swift */,
+				916BF27729D897E500987A60 /* Lesson3View.swift */,
 			);
 			path = Lessons;
 			sourceTree = "<group>";
@@ -270,6 +273,7 @@
 			files = (
 				914F2F1029D8719900045440 /* Lesson1View.swift in Sources */,
 				916BF27629D8913D00987A60 /* Lesson2View.swift in Sources */,
+				916BF27829D897E500987A60 /* Lesson3View.swift in Sources */,
 				914F2F0E29D8719900045440 /* SwiftUI100knocksApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftUI100knocks/Lessons/Lesson3View.swift
+++ b/SwiftUI100knocks/Lessons/Lesson3View.swift
@@ -1,0 +1,23 @@
+//
+//  Lesson3View.swift
+//  SwiftUI100knocks
+//
+//  Created by Juri Ohto on 2023/04/02.
+//
+
+import SwiftUI
+
+struct Lesson3View: View {
+    var body: some View {
+        Image("pyramid")
+            .resizable()
+            .frame(width: 150, height: 150)
+            .clipShape(Circle())
+    }
+}
+
+struct Lesson3View_Previews: PreviewProvider {
+    static var previews: some View {
+        Lesson3View()
+    }
+}


### PR DESCRIPTION
## 課題
150✖︎150サイズに画像をリサイズし、丸く切り取って表示させてください。

## スクリーンショット
| お手本 | 自分の作品 |
| :----: | :----: |
| <img src="https://camo.qiitausercontent.com/72dbd5d186ba314bb874629d2f4c0864f2b1537d/68747470733a2f2f71696974612d696d6167652d73746f72652e73332e61702d6e6f727468656173742d312e616d617a6f6e6177732e636f6d2f302f36333835352f35663363303430622d336465662d393338662d343834622d3434303561633033616639642e706e67" width="300" /> |  <img src="https://user-images.githubusercontent.com/76898162/229304040-f9efa4e4-3101-422d-b2d3-f88afc7db279.png" width="300" /> |
