### PR TITLE
Lesson4: 画像を丸く切り取り、枠を付ける

### DIFF
--- a/SwiftUI100knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100knocks.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		914F2F2B29D8719A00045440 /* SwiftUI100knocksUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914F2F2A29D8719A00045440 /* SwiftUI100knocksUITestsLaunchTests.swift */; };
 		916BF27629D8913D00987A60 /* Lesson2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF27529D8913D00987A60 /* Lesson2View.swift */; };
 		916BF27829D897E500987A60 /* Lesson3View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF27729D897E500987A60 /* Lesson3View.swift */; };
+		916BF27A29D89A5500987A60 /* Lesson4View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF27929D89A5500987A60 /* Lesson4View.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,6 +49,7 @@
 		914F2F2A29D8719A00045440 /* SwiftUI100knocksUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI100knocksUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		916BF27529D8913D00987A60 /* Lesson2View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson2View.swift; sourceTree = "<group>"; };
 		916BF27729D897E500987A60 /* Lesson3View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson3View.swift; sourceTree = "<group>"; };
+		916BF27929D89A5500987A60 /* Lesson4View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson4View.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,6 +139,7 @@
 				914F2F0F29D8719900045440 /* Lesson1View.swift */,
 				916BF27529D8913D00987A60 /* Lesson2View.swift */,
 				916BF27729D897E500987A60 /* Lesson3View.swift */,
+				916BF27929D89A5500987A60 /* Lesson4View.swift */,
 			);
 			path = Lessons;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 				916BF27629D8913D00987A60 /* Lesson2View.swift in Sources */,
 				916BF27829D897E500987A60 /* Lesson3View.swift in Sources */,
 				914F2F0E29D8719900045440 /* SwiftUI100knocksApp.swift in Sources */,
+				916BF27A29D89A5500987A60 /* Lesson4View.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftUI100knocks/Lessons/Lesson3View.swift
+++ b/SwiftUI100knocks/Lessons/Lesson3View.swift
@@ -5,6 +5,10 @@
 //  Created by Juri Ohto on 2023/04/02.
 //
 
+/*
+ 150✖︎150サイズに画像をリサイズし、丸く切り取って表示させてください。
+ */
+
 import SwiftUI
 
 struct Lesson3View: View {

--- a/SwiftUI100knocks/Lessons/Lesson4View.swift
+++ b/SwiftUI100knocks/Lessons/Lesson4View.swift
@@ -19,7 +19,7 @@ struct Lesson4View: View {
             .clipShape(Circle())
             .overlay(
                 Circle()
-                    .stroke(Color.black, lineWidth: 3)
+                    .stroke(Color.black, lineWidth: 4)
             )
     }
 }

--- a/SwiftUI100knocks/Lessons/Lesson4View.swift
+++ b/SwiftUI100knocks/Lessons/Lesson4View.swift
@@ -5,6 +5,10 @@
 //  Created by Juri Ohto on 2023/04/02.
 //
 
+/*
+ 150✖︎150サイズに画像をリサイズし、丸く切り取り、黒い枠を付けて表示させてください。
+ */
+
 import SwiftUI
 
 struct Lesson4View: View {

--- a/SwiftUI100knocks/Lessons/Lesson4View.swift
+++ b/SwiftUI100knocks/Lessons/Lesson4View.swift
@@ -1,0 +1,27 @@
+//
+//  Lesson4View.swift
+//  SwiftUI100knocks
+//
+//  Created by Juri Ohto on 2023/04/02.
+//
+
+import SwiftUI
+
+struct Lesson4View: View {
+    var body: some View {
+        Image("pyramid")
+            .resizable()
+            .frame(width: 150, height: 150)
+            .clipShape(Circle())
+            .overlay(
+                Circle()
+                    .stroke(Color.black, lineWidth: 3)
+            )
+    }
+}
+
+struct Lesson4View_Previews: PreviewProvider {
+    static var previews: some View {
+        Lesson4View()
+    }
+}


### PR DESCRIPTION
## 課題
150✖︎150サイズに画像をリサイズし、丸く切り取り、黒い枠を付けて表示させてください。

## スクリーンショット
| お手本 | 自分の作品 |
| :----: | :----: |
| <img src="https://camo.qiitausercontent.com/8a0530203022c29f08827fe95df614ff5f29468a/68747470733a2f2f71696974612d696d6167652d73746f72652e73332e61702d6e6f727468656173742d312e616d617a6f6e6177732e636f6d2f302f36333835352f33353039353738372d313863322d306466352d393036612d3336616231353937306165382e706e67" width="300" /> |  <img src="https://user-images.githubusercontent.com/76898162/229304785-794125ce-53cc-446d-a27c-74a7b71e002f.png" width="300" /> |
