### PR TITLE
Lesson12: NavigationViewの戻るボタンを非表示にする

### DIFF
--- a/SwiftUI100knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100knocks.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		916BF28B29D9980900987A60 /* Lesson10View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF28A29D9980900987A60 /* Lesson10View.swift */; };
 		916BF28D29DC5BAD00987A60 /* Lesson11_1View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF28C29DC5BAD00987A60 /* Lesson11_1View.swift */; };
 		916BF28F29DC60FC00987A60 /* Lesson11_2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF28E29DC60FC00987A60 /* Lesson11_2View.swift */; };
+		916BF29129DC641900987A60 /* Lesson12_1View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF29029DC641900987A60 /* Lesson12_1View.swift */; };
+		916BF29329DC663200987A60 /* Lesson12_2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916BF29229DC663200987A60 /* Lesson12_2View.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +68,8 @@
 		916BF28A29D9980900987A60 /* Lesson10View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson10View.swift; sourceTree = "<group>"; };
 		916BF28C29DC5BAD00987A60 /* Lesson11_1View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson11_1View.swift; sourceTree = "<group>"; };
 		916BF28E29DC60FC00987A60 /* Lesson11_2View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson11_2View.swift; sourceTree = "<group>"; };
+		916BF29029DC641900987A60 /* Lesson12_1View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson12_1View.swift; sourceTree = "<group>"; };
+		916BF29229DC663200987A60 /* Lesson12_2View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lesson12_2View.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +168,8 @@
 				916BF28A29D9980900987A60 /* Lesson10View.swift */,
 				916BF28C29DC5BAD00987A60 /* Lesson11_1View.swift */,
 				916BF28E29DC60FC00987A60 /* Lesson11_2View.swift */,
+				916BF29029DC641900987A60 /* Lesson12_1View.swift */,
+				916BF29229DC663200987A60 /* Lesson12_2View.swift */,
 			);
 			path = Lessons;
 			sourceTree = "<group>";
@@ -299,6 +305,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				914F2F1029D8719900045440 /* Lesson1View.swift in Sources */,
+				916BF29329DC663200987A60 /* Lesson12_2View.swift in Sources */,
 				916BF27629D8913D00987A60 /* Lesson2View.swift in Sources */,
 				916BF28329D94A1A00987A60 /* Lesson7View.swift in Sources */,
 				916BF28729D954C100987A60 /* Lesson8View.swift in Sources */,
@@ -311,6 +318,7 @@
 				916BF28929D98BC400987A60 /* Lesson9View.swift in Sources */,
 				916BF28B29D9980900987A60 /* Lesson10View.swift in Sources */,
 				916BF27A29D89A5500987A60 /* Lesson4View.swift in Sources */,
+				916BF29129DC641900987A60 /* Lesson12_1View.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftUI100knocks/Lessons/Lesson12_1View.swift
+++ b/SwiftUI100knocks/Lessons/Lesson12_1View.swift
@@ -1,0 +1,36 @@
+//
+//  Lesson12_1View.swift
+//  SwiftUI100knocks
+//
+//  Created by Juri Ohto on 2023/04/04.
+//
+
+// NavigationViewの戻るボタンを非表示にしてください。
+
+import SwiftUI
+
+struct Lesson12_1View: View {
+    private let cities = ["Tokyo",
+                          "Fukuoka",
+                          "Cairo",
+                          "Hurghada",
+                          "Moscow",
+                          "Saint Petersburg"
+    ]
+
+    var body: some View {
+        NavigationView {
+            List(cities, id: \.self) { city in
+                NavigationLink(destination: Lesson12_2View(city: city)) {
+                    Text(city)
+                }
+            }
+        }
+    }
+}
+
+struct Lesson12_1View_Previews: PreviewProvider {
+    static var previews: some View {
+        Lesson12_1View()
+    }
+}

--- a/SwiftUI100knocks/Lessons/Lesson12_2View.swift
+++ b/SwiftUI100knocks/Lessons/Lesson12_2View.swift
@@ -1,0 +1,23 @@
+//
+//  Lesson12_2View.swift
+//  SwiftUI100knocks
+//
+//  Created by Juri Ohto on 2023/04/04.
+//
+
+import SwiftUI
+
+struct Lesson12_2View: View {
+    let city: String
+
+    var body: some View {
+        Text(city)
+            .navigationBarBackButtonHidden()
+    }
+}
+
+struct Lesson12_2View_Previews: PreviewProvider {
+    static var previews: some View {
+        Lesson12_2View(city: "Tokyo")
+    }
+}


### PR DESCRIPTION
## 課題
NavigationViewの戻るボタンを非表示にしてください。

## スクリーンショット
| お手本 | 自分の作品 |
| :----: | :----: |
| <img src="https://camo.qiitausercontent.com/3cf6f926e9bbd0b0f2ae0ea515d85064eef6ea3e/68747470733a2f2f71696974612d696d6167652d73746f72652e73332e61702d6e6f727468656173742d312e616d617a6f6e6177732e636f6d2f302f36333835352f61343365316565632d383531662d646239342d383533372d3530316464656265376333362e676966" width="300" /> |  <video src="https://user-images.githubusercontent.com/76898162/229819795-61767093-f7dc-4d64-b9ba-e8d0c7200edd.mp4" width="300" /> |

## 備考
遷移先の画面に `.navigationBarBackButtonHidden()` をつけただけ
https://developer.apple.com/documentation/swiftui/view/navigationbarbackbuttonhidden(_:)


